### PR TITLE
Only scroll nearest scrollable container

### DIFF
--- a/src/lib/code/CodeBlock.svelte
+++ b/src/lib/code/CodeBlock.svelte
@@ -73,7 +73,7 @@
 		if (browser) {
 			document
 				.getElementById(`svhighlight-${uniqueID}-line-${line}`)
-				?.scrollIntoView({ behavior: 'smooth', inline: 'center' });
+				?.scrollIntoView({ behavior: 'smooth', inline: 'center', block: 'nearest' });
 		}
 	};
 


### PR DESCRIPTION
Fixes scrolling multiple containers when triggering/handling a `FocusBlock`. This will now just scroll the `'nearest'` container, i.e. the code display block.